### PR TITLE
Issue 19: Updating content/front-end title guidance

### DIFF
--- a/app/views/guidance-for-your-job-role/content-designer/partials/page-title.md
+++ b/app/views/guidance-for-your-job-role/content-designer/partials/page-title.md
@@ -1,11 +1,5 @@
 ### Page title
 
-Titles should describe the topic or purpose of the page. They are usually identical to the H1, apart from when the H1 contains identifiable information.
-
-For example, if the H1 is "What is your date of birth?" then the title would be the same.
-
-However, sometimes the H1 can contain personal information, for example "What is John Smith's date of birth". In this case, the title should not be the same as there is a risk the information would be sent as analytics data.
-
-In cases like this, the title should be as close as possible but not identical. For example, "What is your partners date of birth?".
+{% include '../../shared/page-title.njk' %}
 
 You should work with a Frontend Developer and QA Tester to make sure the titles are correct when deciding if the page is finished.

--- a/app/views/guidance-for-your-job-role/shared/page-title.njk
+++ b/app/views/guidance-for-your-job-role/shared/page-title.njk
@@ -1,0 +1,19 @@
+Titles should describe the topic or purpose of the page. 
+
+The standard format for titles on a service is to set the context in 3 parts and separate them using en dashes (not hyphens). The 3 parts are:  
+'Page context – Service context – Domain context`.
+
+For example:
+```html
+~~<title>What is your name? – Apply for Universal Credit – GOV.UK</title>
+```
+
+Page context should describe the topic or purpose of the page. They are usually identical to the H1, apart from when the H1 contains identifiable information.
+
+For example, if the H1 is "What is your date of birth?" then the title would be the same.
+
+However, sometimes the H1 can contain personal information, for example "What is John Smith's date of birth". In this case, the title should not be the same as there is a risk the information would be sent as analytics data.
+
+In cases like this, the title should be as close as possible but not identical. For example, "What is your partners date of birth?".
+
+If there are errors on the page, then the page context part of the title should be prefixed with `Error:`. You can read more about this on the [GOV.UK pattern for validation errors](https://design-system.service.gov.uk/patterns/validation/).

--- a/app/views/guidance-for-your-job-role/software-engineer-or-frontend-developer/partials/page-title.md
+++ b/app/views/guidance-for-your-job-role/software-engineer-or-frontend-developer/partials/page-title.md
@@ -1,21 +1,5 @@
 ### Page title
 
-The standard format for titles on a service is to set the context in 3 parts and separate them using en dashes (not hyphens). The 3 parts are:  
-'Page context – Service context – Domain context`.
-
-For example:
-```html
-~~<title>What is your name? – Apply for Universal Credit – GOV.UK</title>
-```
-
-Page context should describe the topic or purpose of the page. They are usually identical to the H1, apart from when the H1 contains identifiable information.
-
-For example, if the H1 is "What is your date of birth?" then the title would be the same.
-
-However, sometimes the H1 can contain personal information, for example "What is John Smith's date of birth". In this case, the title should not be the same as there is a risk the information would be sent as analytics data.
-
-In cases like this, the title should be as close as possible but not identical. For example, "What is your partners date of birth?".
-
-If there are errors on the page, then the page context part of the title should be prefixed with `Error:`. You can read more about this on the [GOV.UK pattern for validation errors](https://design-system.service.gov.uk/patterns/validation/).
+{% include '../../shared/page-title.njk' %}
 
 You should work with a Content Designer and QA Tester to make sure the titles are correct when deciding if the page is finished.


### PR DESCRIPTION
Just a follow up, since I flagged it.

I've assumed the content is best merged as a shared step, with the technical guidance overlaid

Happy to change it but figured this was a decent starting point.