### PR TITLE
Fix name for axe-core

### DIFF
--- a/app/views/best-practice/automated-accessibility-testing/README.md
+++ b/app/views/best-practice/automated-accessibility-testing/README.md
@@ -10,7 +10,7 @@ A [GDS audit of automated tools](https://alphagov.github.io/accessibility-tool-a
 
 As part of your continuous integration (CI) pipeline, you should include automated accessibility testing. It won't find everything, but it may stop you from deploying code which has introduced accessibility errors into your service.
 
-There are a few tools which do this but we recommend using [AxeCore](https://github.com/dequelabs/axe-core).
+There are a few tools which do this but we recommend using [axe-core](https://github.com/dequelabs/axe-core).
 
 ## Using browser plugins
 

--- a/app/views/best-practice/manual-accessibility-testing/partials/keyboard-only.md
+++ b/app/views/best-practice/manual-accessibility-testing/partials/keyboard-only.md
@@ -1,6 +1,6 @@
 ### Keyboard only
 
-As part of your manual tests you need to make sure the page works as expected using just a keyboard. Every part of the page must be able to be viewed, and every interactive element must be usable.
+As part of your manual tests you need to make sure the page works as expected using [just a keyboard](https://webaim.org/techniques/keyboard/#testing). Every part of the page must be able to be viewed, and every interactive element must be usable.
 
 Links and form fields can be navigated using the tab key to go to the next item or shift + tab to move the previous one. Radio buttons can usually be navigated with arrow keys.
 


### PR DESCRIPTION
Deque is pretty inconsistent about this, but I've never seen AxeCore written that way. axe-core is most common. Sometimes it is Axe-core.  Think Axe-core is fine though based on https://github.com/dequelabs/axe-core but in this context axe-core is probably best.